### PR TITLE
Add REDO to the memecoin list

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,7 +533,8 @@
 
 | Name | Telegram                            | Jetton Address                                                                                                             | Twitter                                   | Website                           |
 | ---- | ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- | --------------------------------- |
-| Fish | [Telegram](https://t.me/tonfish_en) | [EQATcUc69sGSCCMSadsVUKdGwM1BMKS-HKCWGPk60xZGgwsK](https://tonviewer.com/EQATcUc69sGSCCMSadsVUKdGwM1BMKS-HKCWGPk60xZGgwsK) | [Twitter](https://twitter.com/tonfish_tg) | [Website](https://www.tonfish.io) |
+| Fish | [Telegram](https://t.me/tonfish_en) | [`EQATcUc69sGSCCMSadsVUKdGwM1BMKS-HKCWGPk60xZGgwsK`](https://tonviewer.com/EQATcUc69sGSCCMSadsVUKdGwM1BMKS-HKCWGPk60xZGgwsK) | [Twitter](https://twitter.com/tonfish_tg) | [Website](https://www.tonfish.io) |
+| Redo | [Telegram](https://t.me/redoton) | [`EQBZ_cafPyDr5KUTs0aNxh0ZTDhkpEZONmLJA2SNGlLm4Cko`](https://tonviewer.com/EQBZ_cafPyDr5KUTs0aNxh0ZTDhkpEZONmLJA2SNGlLm4Cko) | [Twitter](https://twitter.com/redoonton) | [Website](https://www.redoton.com) |
 
 ### Disclaimer for Jetton Inclusion Criteria
 


### PR DESCRIPTION
> $REDO is the ticker of Resistance Dog, a token on the $TON BlockChain.

As of the time of this PR, REDO has met the requirements for:
- [x] The token should have a minimum of 1,000 unique holders: REDO has [5252 holders](https://tonviewer.com/EQBZ_cafPyDr5KUTs0aNxh0ZTDhkpEZONmLJA2SNGlLm4Cko?section=holders).
- [x] Fully Diluted Valuation (FDV) of at least $1 million: REDO's FDV is $17,230,000.
- [x] Total Value Locked (TVL) exceeding $100,000: REDO has a liquidity of around $370,000, and 90.96% of which has been burnt.

Socials:
- [GeckoTerminal chart](https://www.geckoterminal.com/ton/pools/EQBCwe_IObXA4Mt3RbcHil2s4-v4YQS3wUDt1-DvZOceeMGO)
- [Twitter](https://twitter.com/redoonton)
- [Telegram](https://t.me/redoton)
- [Website](https://redoton.com)

---
Also made the Jetton Address URLs' text monospace.