### PR TITLE
Update: Add MugglePay - Payments on TON

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,7 @@
 | TonoGram    | [Telegram](https://t.me/tonogrampremiumbot) |        |         |                                    |
 | monomenu    | [Telegram](https://t.me/monodashboardbot)   |        |         |                                    |
 | Xtontracker | [Telegram](https://t.me/xtontracker)        |        |         | [Website](https://xtontracker.com) |
+| MugglePay   | [Telegram](https://t.me/mugglechatbot)      | [GitHub](https://github.com/mugglepay) | [Twitter](https://twitter.com/paymuggle)        | [Website](https://ton.mugglepay.com/)       |
 
 ## Marketplaces
 
@@ -475,6 +476,8 @@
 | Cryptopay   | [Telegram](https://t.me/cryptopayme) | [GitHub](https://github.com/cryptopay-dev) | [Twitter](https://twitter.com/cryptopay)    | [Website](https://cryptopay.me/en/) |
 | @Tribute    | [Telegram](https://t.me/tribute)     |                                            |                                             | [Website](https://tribute.tg)       |
 | Xtontracker | [Telegram](https://t.me/xtontracker) |                                            |                                             | [Website](https://xtontracker.com)  |
+| MugglePay   | [Telegram](https://t.me/mugglechatbot)      | [GitHub](https://github.com/mugglepay) | [Twitter](https://twitter.com/paymuggle)        | [Website](https://ton.mugglepay.com/)       |
+
 
 ## App Store
 


### PR DESCRIPTION
MugglePay is listed on [Ton Payments](https://ton.org/en/payments) as the Payment Service Provider.
