### PR TITLE
Removes TONX API from the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,7 +501,6 @@
 | NOWNodes             | [Telegram](https://t.me/nownodes)         | [GitHub](https://github.com/NOWNodes)               | [Twitter](https://twitter.com/NowNodes)     | [Website](https://nownodes.io/nodes/toncoin)            |
 | TON SDKs             |                                           |                                                     |                                             | [Website](https://docs.ton.org/develop/dapps/apis/sdk)  |
 | TON ADNL API         |                                           |                                                     |                                             | [Website](https://docs.ton.org/develop/dapps/apis/adnl) |
-| TONX API          | [Telegram](https://t.me/tonxapi)      | [GitHub](https://github.com/tonxapi/sample/)        | [Twitter](https://x.com/TONXAPI)     | [Website](https://tonxapi.com/)                         |
 
 ## Payments
 


### PR DESCRIPTION
TONX API has been removed from the list of resources.